### PR TITLE
fix: oneclick inscription

### DIFF
--- a/oneclick/routes.py
+++ b/oneclick/routes.py
@@ -11,7 +11,10 @@ import random
 
 @bp.route('start', methods=['GET'])
 def show_start():
-    return render_template('/oneclick/start.html')
+    hostname = request.headers.get('Host')
+    protocol = request.scheme    
+    endpoint = protocol + "://" + hostname + "/oneclick-mall/finish"
+    return render_template('/oneclick/start.html', endpoint=endpoint)
 
 
 @bp.route('status', methods=['GET'])

--- a/oneclick_deferred/routes.py
+++ b/oneclick_deferred/routes.py
@@ -14,8 +14,11 @@ import random
 
 
 @bp.route('start', methods=['GET'])
-def show_start():
-    return render_template('/oneclick/deferred/start.html')
+def show_start():    
+    hostname = request.headers.get('Host')
+    protocol = request.scheme    
+    endpoint = protocol + "://" + hostname + "/oneclick-mall-deferred/finish"
+    return render_template('/oneclick/deferred/start.html', endpoint=endpoint)
 
 
 @bp.route('status', methods=['GET'])

--- a/templates/oneclick/deferred/start.html
+++ b/templates/oneclick/deferred/start.html
@@ -25,7 +25,7 @@
  </div>
  <div class="form-group">
     <label for="response_url">Response Url</label>
-    <input class="form-control" id="response_url" name="response_url" value="http://localhost:5000/oneclick-mall-deferred/finish"/>
+    <input class="form-control" id="response_url" name="response_url" value="{{ endpoint }}"/>
   </div>
   <button class="btn btn-primary" type="submit">Iniciar Inscripci&oacute;n</button>
 </form>

--- a/templates/oneclick/start.html
+++ b/templates/oneclick/start.html
@@ -25,7 +25,7 @@
  </div>
  <div class="form-group">
     <label for="response_url">Response Url</label>
-    <input class="form-control" id="response_url" name="response_url" value="http://localhost:5000/oneclick-mall/finish"/>
+    <input class="form-control" id="response_url" name="response_url" value="{{ endpoint }}"/>
   </div>
   <button class="btn btn-primary" type="submit">Iniciar Inscripci&oacute;n</button>
 </form>


### PR DESCRIPTION
This pull request corrects the Oneclick (Normal and Deferred) inscription process which was failing when the server IP was different from 127.0.0.1 due to a hardcoded `return url`.

### Evidence
Before:

https://github.com/TransbankDevelopers/transbank-sdk-python-webpay-rest-example/assets/16856300/c3a7c950-5aef-40f2-8b0a-8e0526669df4

After:

https://github.com/TransbankDevelopers/transbank-sdk-python-webpay-rest-example/assets/16856300/fe269345-9558-41c6-804b-a7541bdc07cd


